### PR TITLE
Change exit event handling to disconnect

### DIFF
--- a/lib/easeCluster.js
+++ b/lib/easeCluster.js
@@ -39,7 +39,7 @@ module.exports = function easeCluster(options, startFunction) {
     .catch(err => console.error(err));
 
   function listen() {
-    cluster.on('exit', revive);
+    cluster.on('disconnect', revive);
     emitter.once('shutdown', shutdown);
     process
       .on('SIGINT', proxySignal)
@@ -65,13 +65,18 @@ module.exports = function easeCluster(options, startFunction) {
   }
 
   function revive(worker, code, signal) {
+    setTimeout(forceKillWorker, opts.grace, worker).unref();
     if (running && Date.now() < runUntil) cluster.fork();
   }
 
   function forceKill() {
     for (var id in cluster.workers) {
-      cluster.workers[id].kill();
+      forceKillWorker(cluster.workers[id]);
     }
     process.exit();
+  }
+
+  function forceKillWorker(worker) {
+    if (!worker.isDead()) worker.kill('SIGKILL');
   }
 };


### PR DESCRIPTION
This lets us spin up another worker process while we gracefully exit
the old one.  Will force kill the process if it takes longer than the
grace period to exit